### PR TITLE
Fix 'call requires API level' errors in demo app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "ch.ebu.peachdemo"
-        minSdkVersion 16
+        minSdkVersion 26
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Demo app requires Android API level 21 and 26.